### PR TITLE
Remove max_size parameter

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -46,7 +46,7 @@ Usage Example
     display = electronutlabs_ili9163.ILI9163(display_bus, width=160, height=128)
 
     # Make the display context
-    splash = displayio.Group(max_size=10)
+    splash = displayio.Group()
     display.show(splash)
 
     color_bitmap = displayio.Bitmap(160, 128, 1)

--- a/examples/ili9163_simpletest.py
+++ b/examples/ili9163_simpletest.py
@@ -20,7 +20,7 @@ display_bus = displayio.FourWire(spi, command=tft_dc, chip_select=tft_cs)
 display = electronutlabs_ili9163.ILI9163(display_bus, width=160, height=128)
 
 # Make the display context
-splash = displayio.Group(max_size=10)
+splash = displayio.Group()
 display.show(splash)
 
 color_bitmap = displayio.Bitmap(160, 128, 1)


### PR DESCRIPTION
Remove the `max_size` parameter. It is no longer used by `displayio.Group`
Ref: adafruit/circuitpython#4959

Update the docs to include the examples.

I don't have a ILI9163 display to test with.